### PR TITLE
Topnav.html: Update Dolphin disclaimer

### DIFF
--- a/_includes/topnav.html
+++ b/_includes/topnav.html
@@ -45,7 +45,7 @@
 
 <div class="container">
 	<div class="alert alert-info">
-		Do you like Lakka ? Would you like to see Dolphin (GameCube and Wii emulator) running on it ? Would you like to support the project ? Say no more ! A bounty has been made to encourage developers to port Dolphin to a libretro core. Any donations are appreciated ! <a href="https://www.bountysource.com/issues/58967981-bounty-update-dolphin-core-and-port-it-to-arm64" target="_blank">Click here to participate to the bounty.</a>
+		Do you like Lakka ? Would you like to see Dolphin (GameCube and Wii emulator) running on it ? Would you like to support the project ? Say no more ! A bounty has been made to encourage developers to update the Dolphin libretro core to support the Switch's internal processor. Any donations are appreciated ! <a href="https://www.bountysource.com/issues/58967981-bounty-update-dolphin-core-and-port-it-to-arm64" target="_blank">Click here to participate to the bounty.</a>
 	</div>
 	<div class="alert alert-info">
 		The battery bug has been <b>FIXED</b> ! Run the fixing tool from Hekate 3.0 then update Lakka and your boot scripts to apply this fix.

--- a/_includes/topnav.html
+++ b/_includes/topnav.html
@@ -45,7 +45,7 @@
 
 <div class="container">
 	<div class="alert alert-info">
-		Do you like Lakka ? Would you like to see Dolphin (GameCube and Wii emulator) running on it ? Would you like to support the project ? Say no more ! A bounty has been made to encourage developers to update the Dolphin libretro core to support the Switch's internal processor. Any donations are appreciated ! <a href="https://www.bountysource.com/issues/58967981-bounty-update-dolphin-core-and-port-it-to-arm64" target="_blank">Click here to participate to the bounty.</a>
+		Do you like Lakka ? Would you like to see Dolphin (GameCube and Wii emulator) running on it ? Would you like to support the project ? Say no more ! A bounty has been made to encourage developers to rewrite the Dolphin libretro core to support the Switch's internal processor. Any donations are appreciated ! <a href="https://www.bountysource.com/issues/58967981-bounty-update-dolphin-core-and-port-it-to-arm64" target="_blank">Click here to participate to the bounty.</a>
 	</div>
 	<div class="alert alert-info">
 		The battery bug has been <b>FIXED</b> ! Run the fixing tool from Hekate 3.0 then update Lakka and your boot scripts to apply this fix.


### PR DESCRIPTION
Dolphin already has a Libretro core, but it doesn't support ARM64, which is one of the goals of the bounty.